### PR TITLE
Additional tuning for zpool and zvol swap device

### DIFF
--- a/debian-stretch-zfs-root.sh
+++ b/debian-stretch-zfs-root.sh
@@ -200,7 +200,7 @@ mkdir -v -m 1777 /target/var/tmp
 mount -t zfs $ZPOOL/var/tmp /target/var/tmp
 chmod 1777 /target/var/tmp
 
-zfs create -V $SIZESWAP -b $(getconf PAGESIZE) -o primarycache=metadata -o com.sun:auto-snapshot=false $ZPOOL/swap
+zfs create -V $SIZESWAP -b $(getconf PAGESIZE) -o primarycache=metadata -o com.sun:auto-snapshot=false -o logbias=throughput -o sync=always $ZPOOL/swap
 mkswap -f /dev/zvol/$ZPOOL/swap
 
 zpool status

--- a/debian-stretch-zfs-root.sh
+++ b/debian-stretch-zfs-root.sh
@@ -177,6 +177,10 @@ for ZFSFEATURE in async_destroy empty_bpobj lz4_compress spacemap_histogram enab
 	zpool set feature@$ZFSFEATURE=enabled $ZPOOL
 done
 zfs set compression=lz4 $ZPOOL
+# The two properties below improve performance but reduce compatibility with non-Linux ZFS implementations
+# Commented out by default
+#zfs set xattr=sa $ZPOOL
+#zfs set acltype=posixacl $ZPOOL
 
 zfs create $ZPOOL/ROOT
 zfs create -o mountpoint=/ $ZPOOL/ROOT/debian-$TARGETDIST


### PR DESCRIPTION
Commit 3d1b245 improves performance and is regarded as safe to use since 0.6.4 [#443](https://github.com/zfsonlinux/zfs/issues/443). However, it is disabled by default in upstream ZoL in order to maximize compatibility with other implementations. I propose that we make these settings visible within the script but commented out so as to not surprise those who do not inspect the script with a ZFS lacking compatibility with Solaris, FreeBSD, etc. I ran this commit uncommented during my install with no problems.

Commit a510445 simply follows suggestions for creating a zvol swap device in the [ZFS on Linux wiki](https://github.com/zfsonlinux/zfs/wiki/FAQ#using-a-zvol-for-a-swap-device). The rationale behind setting `logbias=throughput` and `sync=always` are that: 

> Data written to the volume will be flushed immediately to disk freeing up memory as quickly as possible.

