### PR TITLE
added fix for building module failure and more explict grub-install

### DIFF
--- a/debian-stretch-zfs-root.sh
+++ b/debian-stretch-zfs-root.sh
@@ -262,8 +262,8 @@ chroot /target /usr/sbin/locale-gen
 
 chroot /target /usr/bin/apt-get update
 
-chroot /target /usr/bin/apt-get install --yes linux-image-amd64 grub2-common $GRUBPKG zfs-initramfs zfs-dkms
-grep -q zfs /target/etc/default/grub || perl -i -pe 's/quiet/boot=zfs quiet/' /target/etc/default/grub 
+chroot /target /usr/bin/apt-get install --yes  dpkg-dev linux-headers-$(uname -r) linux-image-amd64 grub2-common $GRUBPKG zfs-initramfs zfs-dkms dosfstools
+grep -q zfs /target/etc/default/grub || perl -i -pe 's/quiet/boot=zfs quiet/' /target/etc/default/grub
 chroot /target /usr/sbin/update-grub
 
 if [ "${GRUBPKG:0:8}" == "grub-efi" ]; then
@@ -275,7 +275,7 @@ if [ "${GRUBPKG:0:8}" == "grub-efi" ]; then
 	for EFIPARTITION in "${EFIPARTITIONS[@]}"; do
 		mkdosfs -F 32 -n EFI-$I $EFIPARTITION
 		mount $EFIPARTITION /target/boot/efi
-		chroot /target /usr/sbin/grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id="Debian $TARGETDIST (RAID disk $I)" --recheck --no-floppy
+		chroot /target /usr/sbin/grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id="Debian $TARGETDIST (RAID disk $I)" --recheck --no-floppy $EFIPARTITION
 		umount $EFIPARTITION
 		if [ $I -gt 0 ]; then
 			EFIBAKPART="#"


### PR DESCRIPTION
FIX 1
-----
The kernel headers are needed to build the module, adding them should get around this:

```
Building initial module for 4.9.0-8-amd64
configure: error:
	*** Please make sure the kmod spl devel <kernel> package for your
	*** distribution is installed then try again.  If that fails you
	*** can specify the location of the spl objects with the
	*** '--with-spl-obj=PATH' option.
Error! Bad return status for module build on kernel: 4.9.0-8-amd64 (x86_64)
```

This is also part of the [Debian ZFS docs](https://github.com/zfsonlinux/zfs/wiki/Debian-Stretch-Root-on-ZFS)(step 1.5)

FIX 2
-----
I also found that when doing ```grub-install``` against what would be ```/dev/sdb```, you need to explicitly callout the path or it fails, my equiv of ```/dev/sda``` is a SSD I use as a ZFS cache disk so the EFI stuff is actually on my ```/dev/sdb```.